### PR TITLE
Add sample-application consuming library

### DIFF
--- a/examples/sample-app.jsonnet
+++ b/examples/sample-app.jsonnet
@@ -1,0 +1,64 @@
+// Demonstrate sample application
+local slo = import '../slo-libsonnet/slo.libsonnet';
+local grafana = import 'grafonnet/grafana.libsonnet';
+local dashboard = grafana.dashboard;
+local row = grafana.row;
+local prometheus = grafana.prometheus;
+
+{
+  local appname = 'fooapp',
+  // Defining reponse code SLO's
+  local errors = slo.errors({
+    metric: 'http_requests_total',  // Name of HTTP request counter metric, partitioned by code
+    selectors: 'namespace="default",job="fooapp"',  // Selectors for specific application
+
+    warning: 5,  // 5% of total requests
+    critical: 10,  // 10% of total requests
+    errorcodes: [400, 404, 500],  // List of codes that are considered against the error budget
+  }),
+  // Defining latency SLO's
+  local latency = slo.latency({
+    metric: 'http_request_duration_seconds',  // Metric name prefix for bucket
+    selectors: 'namespace="default",job="fooapp"',  // Selectors for specific application
+    quantile: 0.99,  // Rules will be generated for 99th Percentile
+    warning: 0.500,  // 500ms
+    critical: 1.0,  // 1s
+  }),
+
+  // Recording rules
+  recordingrule: latency.recordingrule() + errors.recordingrule,
+
+  // Alert rules
+  alerts: [
+    latency.alertWarning,
+    latency.alertCritical,
+    errors.alertWarning,
+    errors.alertCritical,
+  ],
+
+  // Creating a new dashboard
+  local dashboardcontainer = dashboard.new(
+    '%s' % appname,
+    time_from='now-1h',
+  ).addTemplate(
+    {
+      current: {
+        text: 'Prometheus',
+        value: 'Prometheus',
+      },
+      hide: 0,
+      label: null,
+      name: 'datasource',
+      options: [],
+      query: 'prometheus',
+      refresh: 1,
+      regex: '',
+      type: 'datasource',
+    },
+  ).addRow(
+    row.new()
+    .addPanel(latency.grafana.gauge)
+    .addPanel(latency.grafana.graph)
+    .addPanel(errors.grafana.graph)
+  ),
+}


### PR DESCRIPTION
Add a .jsonnet file for a sample application definition that consumes the library and contains definititions for:
- error rate SLO
- latency SLO

And also generates a dashboard for the above. 

The file is heavily commented for the ease of reading.