### PR TITLE
Improve errors recording rules by following upstream formatting

### DIFF
--- a/examples/http-request-errors.jsonnet
+++ b/examples/http-request-errors.jsonnet
@@ -3,10 +3,10 @@ local slo = import '../slo-libsonnet/slo.libsonnet';
 {
   local errors = slo.errors({
     metric: 'promhttp_metric_handler_requests_total',
-    selectors: 'namespace="default",job="fooapp"',
+    selectors: ['namespace="default"', 'job="fooapp"'],
 
-    warning: 5,  // 5% of total requests
-    critical: 10,  // 10% of total requests
+    warning: 0.05,  // 5% of total requests
+    critical: 0.1,  // 10% of total requests
   }),
 
   // Output these as example

--- a/examples/http-request-errors.yaml
+++ b/examples/http-request-errors.yaml
@@ -1,11 +1,19 @@
 alerts:
 - expr: |
-    status_code:promhttp_metric_handler_requests_total:rate:sum{status_code!~"2.."} * 100 / status_code:promhttp_metric_handler_requests_total:rate:sum > 5
+    (
+      sum(status_class:promhttp_metric_handler_requests_total:rate5m{status_class="5xx"})
+    /
+      sum(status_class:promhttp_metric_handler_requests_total:rate5m)
+    ) > 0.050000000000000003
   for: 5m
   labels:
     severity: warning
-- expr: status_code:promhttp_metric_handler_requests_total:rate:sum{status_code!~"2.."}
-    * 100 / status_code:promhttp_metric_handler_requests_total:rate:sum > 10
+- expr: |
+    (
+      sum(status_class:promhttp_metric_handler_requests_total:rate5m{status_class="5xx"})
+    /
+      sum(status_class:promhttp_metric_handler_requests_total:rate5m)
+    ) > 0.10000000000000001
   for: 5m
   labels:
     severity: critical
@@ -14,11 +22,15 @@ grafana:
     "#EF843C", "5xx": "#E24D42", "error": "#E24D42", "success": "#7EB26D"}, "datasource":
     "$datasource", "legend": {"avg": false, "current": false, "max": false, "min":
     false, "show": true, "total": false, "values": false}, "span": 12, "targets":
-    [{"expr": "status_code:promhttp_metric_handler_requests_total:rate:sum", "format":
-    "time_series", "intervalFactor": 2, "legendFormat": "{{status_code}}", "refId":
+    [{"expr": "status_class:promhttp_metric_handler_requests_total:rate5m", "format":
+    "time_series", "intervalFactor": 2, "legendFormat": "{{status_class}}", "refId":
     "A", "step": 10}], "title": "HTTP Response Codes", "tooltip": {"shared": true,
     "sort": 0, "value_type": "individual"}, "type": "graph"}'
 recordingrule:
   expr: |
-    sum(label_replace(rate(promhttp_metric_handler_requests_total{namespace="default",job="fooapp"}[10m]), "status_code", "${1}xx", "code", "([0-9])..")) by (status_code)
-  record: status_code:promhttp_metric_handler_requests_total:rate:sum
+    sum by (status_class) (
+      label_replace(
+        rate(promhttp_metric_handler_requests_total{namespace="default",job="fooapp"}[5m]
+      ), "status_class", "${1}xx", "code", "([0-9])..")
+    )
+  record: status_class:promhttp_metric_handler_requests_total:rate5m

--- a/slo-libsonnet/errors.libsonnet
+++ b/slo-libsonnet/errors.libsonnet
@@ -3,22 +3,37 @@
     local slo = {
       metric: error 'must set metric for errors',
       selectors: error 'must set selectors for errors',
+      rate: '5m',
+      codeSelector: 'code',
     } + param,
 
     local recordingrule = {
       expr: |||
-        sum(label_replace(rate(%s{%s}[10m]), "status_code", "${1}xx", "code", "([0-9])..")) by (status_code)
+        sum by (status_class) (
+          label_replace(
+            rate(%s{%s}[%s]
+          ), "status_class", "${1}xx", "%s", "([0-9])..")
+        )
       ||| % [
         slo.metric,
-        slo.selectors,
+        std.join(',', slo.selectors),
+        slo.rate,
+        slo.codeSelector,
       ],
-      record: 'status_code:%s:rate:sum' % slo.metric,
+      record: 'status_class:%s:rate%s' % [
+        slo.metric,
+        slo.rate,
+      ],
     },
     recordingrule: recordingrule,
 
     alertWarning: {
       expr: |||
-        %s{status_code!~"2.."} * 100 / %s > %s
+        (
+          sum(%s{status_class="5xx"})
+        /
+          sum(%s)
+        ) > %s
       ||| % [
         recordingrule.record,
         recordingrule.record,
@@ -31,7 +46,17 @@
     },
 
     alertCritical: {
-      expr: '%s{status_code!~"2.."} * 100 / %s > %s' % [recordingrule.record, recordingrule.record, slo.critical],
+      expr: |||
+        (
+          sum(%s{status_class="5xx"})
+        /
+          sum(%s)
+        ) > %s
+      ||| % [
+        recordingrule.record,
+        recordingrule.record,
+        slo.critical,
+      ],
       'for': '5m',
       labels: {
         severity: 'critical',
@@ -65,7 +90,7 @@
             expr: '%s' % recordingrule.record,
             format: 'time_series',
             intervalFactor: 2,
-            legendFormat: '{{status_code}}',
+            legendFormat: '{{status_class}}',
             refId: 'A',
             step: 10,
           },


### PR DESCRIPTION
These are first improvements to the current errors recording rules.

I am going to keep the relabeling to status_class with `2xx, 3xx, 4xx, 5xx`, as we want to be able to show these aggregated in dashboards. For recording rules we _could_ use regexp matchers, but then we have 2 ways of doing t he same thing.

/cc @beorn7 @brancz @squat @aditya-konarde @kakkoyun