### PR TITLE
Add option to merge additional labels

### DIFF
--- a/examples/http-request-errors.yaml
+++ b/examples/http-request-errors.yaml
@@ -7,6 +7,8 @@ alerts:
     ) > 0.050000000000000003
   for: 5m
   labels:
+    job: fooapp
+    namespace: default
     severity: warning
 - expr: |
     (
@@ -16,6 +18,8 @@ alerts:
     ) > 0.10000000000000001
   for: 5m
   labels:
+    job: fooapp
+    namespace: default
     severity: critical
 grafana:
   graph: '{"aliasColors": {"1xx": "#EAB839", "2xx": "#7EB26D", "3xx": "#6ED0E0", "4xx":
@@ -33,4 +37,7 @@ recordingrule:
         rate(promhttp_metric_handler_requests_total{namespace="default",job="fooapp"}[5m]
       ), "status_class", "${1}xx", "code", "([0-9])..")
     )
+  labels:
+    job: fooapp
+    namespace: default
   record: status_class:promhttp_metric_handler_requests_total:rate5m

--- a/examples/http-request-latency.jsonnet
+++ b/examples/http-request-latency.jsonnet
@@ -3,7 +3,7 @@ local slo = import '../slo-libsonnet/slo.libsonnet';
 {
   local latency = slo.latency({
     metric: 'prometheus_http_request_duration_seconds',
-    selectors: 'namespace="default",job="fooapp"',
+    selectors: ['namespace="default"', 'job="fooapp"'],
     quantile: 0.99,
 
     warning: 0.500,  // 500ms

--- a/examples/http-request-latency.yaml
+++ b/examples/http-request-latency.yaml
@@ -3,11 +3,15 @@ alerts:
     prometheus_http_request_duration_seconds:histogram_quantile > 0.500
   for: 5m
   labels:
+    job: fooapp
+    namespace: default
     severity: warning
 - expr: |
     prometheus_http_request_duration_seconds:histogram_quantile > 1.000
   for: 5m
   labels:
+    job: fooapp
+    namespace: default
     severity: critical
 grafana:
   gauge: '{"datasource": "$datasource", "options": {"maxValue": "1.5", "minValue":
@@ -28,7 +32,9 @@ grafana:
     {"align": false, "alignLevel": null}}'
 recordingrule:
   expr: |
-    histogram_quantile(0.99, sum(prometheus_http_request_duration_seconds_bucket{namespace="default",job="fooapp"}) by (le))
+    histogram_quantile(0.99, sum(prometheus_http_request_duration_seconds_bucket{["namespace=\"default\"", "job=\"fooapp\""]}) by (le))
   labels:
+    job: fooapp
+    namespace: default
     quantile: "0.99"
   record: prometheus_http_request_duration_seconds:histogram_quantile

--- a/slo-libsonnet/_util.libsonnet
+++ b/slo-libsonnet/_util.libsonnet
@@ -1,0 +1,9 @@
+{
+  selectorsToLabels(labelset):: {
+    [s[0]]: std.strReplace(s[1], '"', '')
+    for s in [
+      std.split(s, '=')
+      for s in labelset
+    ]
+  },
+}

--- a/slo-libsonnet/errors.libsonnet
+++ b/slo-libsonnet/errors.libsonnet
@@ -1,11 +1,18 @@
+local util = import '_util.libsonnet';
+
 {
   errors(param):: {
     local slo = {
       metric: error 'must set metric for errors',
       selectors: error 'must set selectors for errors',
+      labels: [],
       rate: '5m',
       codeSelector: 'code',
     } + param,
+
+    local labels =
+      util.selectorsToLabels(slo.selectors) +
+      util.selectorsToLabels(slo.labels),
 
     local recordingrule = {
       expr: |||
@@ -24,6 +31,7 @@
         slo.metric,
         slo.rate,
       ],
+      labels: labels,
     },
     recordingrule: recordingrule,
 
@@ -40,7 +48,7 @@
         slo.warning,
       ],
       'for': '5m',
-      labels: {
+      labels: labels {
         severity: 'warning',
       },
     },
@@ -58,7 +66,7 @@
         slo.critical,
       ],
       'for': '5m',
-      labels: {
+      labels: labels {
         severity: 'critical',
       },
     },


### PR DESCRIPTION
@aditya-konarde requested to be able to add additional labels like `['component="foobar"']` to the labelset on each rule and alert.

/cc @brancz 