### PR TITLE
fix selectors for latency recording rules

### DIFF
--- a/slo-libsonnet/latency.libsonnet
+++ b/slo-libsonnet/latency.libsonnet
@@ -19,7 +19,7 @@ local util = import '_util.libsonnet';
       ||| % [
         quantile,
         slo.metric,
-        slo.selectors,
+        std.join(',', slo.selectors),,
       ],
       record: '%s:histogram_quantile' % slo.metric,
 


### PR DESCRIPTION
The missing `std.join` created an array in the recording rule which is invalid. I added the same fix as in `errors.libsonnet`.