### PR TITLE
bug fix: handle expressions with '!'

### DIFF
--- a/slo-libsonnet/_util.libsonnet
+++ b/slo-libsonnet/_util.libsonnet
@@ -1,8 +1,17 @@
 {
+  local splitExpression(s) =
+      local cleaned = std.strReplace(s, '~', '');
+      local seperators = ["=", "!"];
+      local results = [std.split(cleaned, sperator)
+      for sperator in seperators];
+
+      local match = std.filter(function(arr) std.length(arr) > 1, results);
+
+      if std.length(match) == 1 then match[0] else error "unable to parse selector " + s,
   selectorsToLabels(labelset):: {
     [s[0]]: std.strReplace(s[1], '"', '')
     for s in [
-      std.split(s, '=')
+      splitExpression(s)
       for s in labelset
     ]
   },


### PR DESCRIPTION
`selectorsToLabels` was handling only `=`, but not taking into account other separators like `!`, `!~`. `=~`. I fixed this bug. 