### PR TITLE
Fix and imrpve latency-burn.libsonnet

### DIFF
--- a/examples/http-request-latency-burnrate.jsonnet
+++ b/examples/http-request-latency-burnrate.jsonnet
@@ -1,7 +1,7 @@
-local latency = import '../slo-libsonnet/latency-burn.libsonnet';
+local slo = import '../slo-libsonnet/slo.libsonnet';
 
 {
-  local query = latency.burn({
+  local query = slo.latencyburn({
     metric: 'http_request_duration_seconds',
     selectors: ['namespace="default"','job="fooapp"'],
     # How much responce delay is too much.

--- a/examples/http-request-latency-burnrate.yaml
+++ b/examples/http-request-latency-burnrate.yaml
@@ -2,15 +2,15 @@ alerts:
 - alert: ErrorBudgetBurn
   expr: |
     (
-      latency1s:http_request_duration_seconds:rate1h > (14.4*0.010000)
+      latencytarget:http_request_duration_seconds:rate1h > (14.4*0.010000)
       and
-      latency1s:http_request_duration_seconds:rate5m > (14.4*0.010000)
+      latencytarget:http_request_duration_seconds:rate5m > (14.4*0.010000)
     )
     or
     (
-      latency1s:http_request_duration_seconds:rate6h > (6*0.010000)
+      latencytarget:http_request_duration_seconds:rate6h > (6*0.010000)
       and
-      latency1s:http_request_duration_seconds:rate30m > (6*0.010000)
+      latencytarget:http_request_duration_seconds:rate30m > (6*0.010000)
     )
   labels:
     job: fooapp
@@ -19,15 +19,15 @@ alerts:
 - alert: ErrorBudgetBurn
   expr: |
     (
-      latency1s:http_request_duration_seconds:rate1d > (3*0.010000)
+      latencytarget:http_request_duration_seconds:rate1d > (3*0.010000)
       and
-      latency1s:http_request_duration_seconds:rate2h > (3*0.010000)
+      latencytarget:http_request_duration_seconds:rate2h > (3*0.010000)
     )
     or
     (
-      latency1s:http_request_duration_seconds:rate3d > (0.010000)
+      latencytarget:http_request_duration_seconds:rate3d > (0.010000)
       and
-      latency1s:http_request_duration_seconds:rate6h > (0.010000)
+      latencytarget:http_request_duration_seconds:rate6h > (0.010000)
     )
   labels:
     job: fooapp
@@ -43,7 +43,7 @@ recordingrule:
   labels:
     job: fooapp
     namespace: default
-  record: latency1s:http_request_duration_seconds:rate5m
+  record: latencytarget:http_request_duration_seconds:rate5m
 - expr: |
     1 - (
       sum(rate(http_request_duration_seconds_bucket{namespace="default",job="fooapp",le="1",code!~"5.."}[30m]))
@@ -53,7 +53,7 @@ recordingrule:
   labels:
     job: fooapp
     namespace: default
-  record: latency1s:http_request_duration_seconds:rate30m
+  record: latencytarget:http_request_duration_seconds:rate30m
 - expr: |
     1 - (
       sum(rate(http_request_duration_seconds_bucket{namespace="default",job="fooapp",le="1",code!~"5.."}[1h]))
@@ -63,7 +63,7 @@ recordingrule:
   labels:
     job: fooapp
     namespace: default
-  record: latency1s:http_request_duration_seconds:rate1h
+  record: latencytarget:http_request_duration_seconds:rate1h
 - expr: |
     1 - (
       sum(rate(http_request_duration_seconds_bucket{namespace="default",job="fooapp",le="1",code!~"5.."}[2h]))
@@ -73,7 +73,7 @@ recordingrule:
   labels:
     job: fooapp
     namespace: default
-  record: latency1s:http_request_duration_seconds:rate2h
+  record: latencytarget:http_request_duration_seconds:rate2h
 - expr: |
     1 - (
       sum(rate(http_request_duration_seconds_bucket{namespace="default",job="fooapp",le="1",code!~"5.."}[6h]))
@@ -83,7 +83,7 @@ recordingrule:
   labels:
     job: fooapp
     namespace: default
-  record: latency1s:http_request_duration_seconds:rate6h
+  record: latencytarget:http_request_duration_seconds:rate6h
 - expr: |
     1 - (
       sum(rate(http_request_duration_seconds_bucket{namespace="default",job="fooapp",le="1",code!~"5.."}[1d]))
@@ -93,7 +93,7 @@ recordingrule:
   labels:
     job: fooapp
     namespace: default
-  record: latency1s:http_request_duration_seconds:rate1d
+  record: latencytarget:http_request_duration_seconds:rate1d
 - expr: |
     1 - (
       sum(rate(http_request_duration_seconds_bucket{namespace="default",job="fooapp",le="1",code!~"5.."}[3d]))
@@ -103,4 +103,4 @@ recordingrule:
   labels:
     job: fooapp
     namespace: default
-  record: latency1s:http_request_duration_seconds:rate3d
+  record: latencytarget:http_request_duration_seconds:rate3d

--- a/slo-libsonnet/latency-burn.libsonnet
+++ b/slo-libsonnet/latency-burn.libsonnet
@@ -7,6 +7,7 @@ local util = import '_util.libsonnet';
       latencyTarget: error 'must set latencyTarget latency burn',
       latencyBudget: error 'must set latencyBudget latency burn',
       labels: [],
+      codeSelector: 'code',
     } + param,
 
     local rates = ['5m', '30m', '1h', '2h', '6h', '1d', '3d'],
@@ -22,7 +23,7 @@ local util = import '_util.libsonnet';
         // This gives the total requests that fail the SLO
         expr: |||
           1 - (
-            sum(rate(%s{%s,le="%s",code!~"5.."}[%s]))
+            sum(rate(%s{%s,le="%s",%s!~"5.."}[%s]))
             /
             sum(rate(%s{%s}[%s]))
           )

--- a/slo-libsonnet/latency-burn.libsonnet
+++ b/slo-libsonnet/latency-burn.libsonnet
@@ -37,7 +37,7 @@ local util = import '_util.libsonnet';
           std.join(',', slo.selectors),
           rate,
         ],
-        record: 'latency%s:%s:rate%s' % [slo.latencyTarget+"s",slo.metric, rate],
+        record: 'latencytarget:%s:rate%s' % [slo.metric, rate],
         labels: labels,
       }
       for rate in rates

--- a/slo-libsonnet/latency-burn.libsonnet
+++ b/slo-libsonnet/latency-burn.libsonnet
@@ -1,6 +1,6 @@
 local util = import '_util.libsonnet';
 {
-  burn(param):: {
+  latencyburn(param):: {
     local slo = {
       metric: error 'must set metric for latency burn',
       selectors: error 'must set selectors for latency burn',

--- a/slo-libsonnet/latency-burn.libsonnet
+++ b/slo-libsonnet/latency-burn.libsonnet
@@ -16,10 +16,10 @@ local util = import '_util.libsonnet';
 
     local latencyRules = [
       {
-        # How many percent are above the SLO latency target.
-        # First calculate how many requests are below the target and
-        # substract those from 100 percent.
-        # This gives the total requests that fail the SLO
+        // How many percent are above the SLO latency target.
+        // First calculate how many requests are below the target and
+        // substract those from 100 percent.
+        // This gives the total requests that fail the SLO
         expr: |||
           1 - (
             sum(rate(%s{%s,le="%s",code!~"5.."}[%s]))
@@ -27,11 +27,12 @@ local util = import '_util.libsonnet';
             sum(rate(%s{%s}[%s]))
           )
         ||| % [
-          slo.metric + "_bucket",
+          slo.metric + '_bucket',
           std.join(',', slo.selectors),
           slo.latencyTarget,
+          slo.codeSelector,
           rate,
-          slo.metric + "_count",
+          slo.metric + '_count',
           std.join(',', slo.selectors),
           rate,
         ],
@@ -46,8 +47,8 @@ local util = import '_util.libsonnet';
     local multiBurnRate30d = [
       {
         alert: 'ErrorBudgetBurn',
-        # Check how many procent are violating the SLO.
-        # Send an alert only when this procent is above the burn rate.
+        // Check how many procent are violating the SLO.
+        // Send an alert only when this procent is above the burn rate.
         expr: |||
           (
             %s > (14.4*%f)


### PR DESCRIPTION
There are a couple of things done in this PR:

1. Run jsonnetfmt to be consistent
1. Rename `burn` to `latencyburn`, because it's global function and `burn` doesn't really mean anything.
1. We want to use the `codeSelector` just like in the error-burn for when something like nginx ingress uses `status` and not `code` as label.
1. The actual bug I found was that `latency0.5s:nginx_ingress_controller_request_duration_seconds:rate1h` doesn't work because there's a dot in the latency target... 

/cc @krasi-georgiev 