### PR TITLE
Create errorlatency which combines errors and latency for a combined error budget

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,11 @@
 all: examples
 
-examples: examples/vendor examples/http-request-latency-burnrate.yaml examples/http-request-error-burnrate.yaml examples/http-request-errors.yaml examples/http-request-latency.yaml
+examples: \
+	examples/http-request-error-burnrate.yaml \
+	examples/http-request-errorlatency-burnrate.yaml \
+	examples/http-request-errors.yaml \
+	examples/http-request-latency-burnrate.yaml \
+	examples/http-request-latency.yaml
 
 examples/vendor: examples/jsonnetfile.json examples/jsonnetfile.lock.json .bingo/jb
 	cd examples && ../.bingo/jb install
@@ -8,6 +13,10 @@ examples/vendor: examples/jsonnetfile.json examples/jsonnetfile.lock.json .bingo
 examples/http-request-error-burnrate.yaml: examples/http-request-error-burnrate.jsonnet .bingo/jsonnetfmt .bingo/jsonnet .bingo/gojsontoyaml
 	.bingo/jsonnetfmt -i examples/http-request-error-burnrate.jsonnet
 	.bingo/jsonnet -J examples/vendor examples/http-request-error-burnrate.jsonnet | .bingo/gojsontoyaml > examples/http-request-error-burnrate.yaml
+
+examples/http-request-errorlatency-burnrate.yaml: examples/http-request-errorlatency-burnrate.jsonnet .bingo/jsonnetfmt .bingo/jsonnet .bingo/gojsontoyaml
+	.bingo/jsonnetfmt -i examples/http-request-errorlatency-burnrate.jsonnet
+	.bingo/jsonnet -J examples/vendor examples/http-request-errorlatency-burnrate.jsonnet | .bingo/gojsontoyaml > examples/http-request-errorlatency-burnrate.yaml
 
 examples/http-request-errors.yaml: examples/http-request-errors.jsonnet .bingo/jsonnetfmt .bingo/jsonnet .bingo/gojsontoyaml
 	.bingo/jsonnetfmt -i examples/http-request-errors.jsonnet

--- a/examples/http-request-errorlatency-burnrate.jsonnet
+++ b/examples/http-request-errorlatency-burnrate.jsonnet
@@ -1,0 +1,16 @@
+local slo = import '../slo-libsonnet/slo.libsonnet';
+
+{
+  local errorlatencyburn = slo.errorlatencyburn({
+    alertName: 'ErrorBudgetBurn',
+    // This metric probably doesn't make a lot of sense.
+    // However, it is availabe on every Prometheus by default.
+    metric: 'http_request_duration_seconds',
+    selectors: ['namespace="default"', 'job="fooapp"'],
+    target: 0.999,
+  }),
+
+  // Output these as example
+  recordingrule: errorlatencyburn.recordingrules,
+  alerts: errorlatencyburn.alerts,
+}

--- a/examples/http-request-errorlatency-burnrate.yaml
+++ b/examples/http-request-errorlatency-burnrate.yaml
@@ -1,0 +1,147 @@
+alerts:
+- alert: ErrorBudgetBurn
+  annotations:
+    message: App is burning too much error budget
+  expr: |
+    sum(http_request_duration_seconds:burnrate1h) > (14.40 * 0.00100)
+    and
+    sum(http_request_duration_seconds:burnrate5m) > (14.40 * 0.00100)
+  for: 2m
+  labels:
+    severity: critical
+- alert: ErrorBudgetBurn
+  annotations:
+    message: App is burning too much error budget
+  expr: |
+    sum(http_request_duration_seconds:burnrate6h) > (6.00 * 0.00100)
+    and
+    sum(http_request_duration_seconds:burnrate30m) > (6.00 * 0.00100)
+  for: 15m
+  labels:
+    severity: critical
+- alert: ErrorBudgetBurn
+  annotations:
+    message: App is burning too much error budget
+  expr: |
+    sum(http_request_duration_seconds:burnrate1d) > (3.00 * 0.00100)
+    and
+    sum(http_request_duration_seconds:burnrate2h) > (3.00 * 0.00100)
+  for: 1h
+  labels:
+    severity: warning
+- alert: ErrorBudgetBurn
+  annotations:
+    message: App is burning too much error budget
+  expr: |
+    sum(http_request_duration_seconds:burnrate3d) > (1.00 * 0.00100)
+    and
+    sum(http_request_duration_seconds:burnrate6h) > (1.00 * 0.00100)
+  for: 3h
+  labels:
+    severity: warning
+recordingrule:
+- expr: |
+    (
+      (
+        # sum of too slow requests
+        sum(rate(http_request_duration_seconds_count{namespace="default",job="fooapp",code!~"5.."}[1d]))
+        -
+        sum(rate(http_request_duration_seconds_bucket{namespace="default",job="fooapp",code!~"5..",le="1"}[1d]))
+      )
+      +
+      # sum of errors
+      sum(rate(http_request_duration_seconds_count{namespace="default",job="fooapp",code=~"5.."}[1d]))
+    )
+    /
+    sum(rate(http_request_duration_seconds_count{namespace="default",job="fooapp"}[1d]))
+  record: http_request_duration_seconds:burnrate1d
+- expr: |
+    (
+      (
+        # sum of too slow requests
+        sum(rate(http_request_duration_seconds_count{namespace="default",job="fooapp",code!~"5.."}[1h]))
+        -
+        sum(rate(http_request_duration_seconds_bucket{namespace="default",job="fooapp",code!~"5..",le="1"}[1h]))
+      )
+      +
+      # sum of errors
+      sum(rate(http_request_duration_seconds_count{namespace="default",job="fooapp",code=~"5.."}[1h]))
+    )
+    /
+    sum(rate(http_request_duration_seconds_count{namespace="default",job="fooapp"}[1h]))
+  record: http_request_duration_seconds:burnrate1h
+- expr: |
+    (
+      (
+        # sum of too slow requests
+        sum(rate(http_request_duration_seconds_count{namespace="default",job="fooapp",code!~"5.."}[2h]))
+        -
+        sum(rate(http_request_duration_seconds_bucket{namespace="default",job="fooapp",code!~"5..",le="1"}[2h]))
+      )
+      +
+      # sum of errors
+      sum(rate(http_request_duration_seconds_count{namespace="default",job="fooapp",code=~"5.."}[2h]))
+    )
+    /
+    sum(rate(http_request_duration_seconds_count{namespace="default",job="fooapp"}[2h]))
+  record: http_request_duration_seconds:burnrate2h
+- expr: |
+    (
+      (
+        # sum of too slow requests
+        sum(rate(http_request_duration_seconds_count{namespace="default",job="fooapp",code!~"5.."}[30m]))
+        -
+        sum(rate(http_request_duration_seconds_bucket{namespace="default",job="fooapp",code!~"5..",le="1"}[30m]))
+      )
+      +
+      # sum of errors
+      sum(rate(http_request_duration_seconds_count{namespace="default",job="fooapp",code=~"5.."}[30m]))
+    )
+    /
+    sum(rate(http_request_duration_seconds_count{namespace="default",job="fooapp"}[30m]))
+  record: http_request_duration_seconds:burnrate30m
+- expr: |
+    (
+      (
+        # sum of too slow requests
+        sum(rate(http_request_duration_seconds_count{namespace="default",job="fooapp",code!~"5.."}[3d]))
+        -
+        sum(rate(http_request_duration_seconds_bucket{namespace="default",job="fooapp",code!~"5..",le="1"}[3d]))
+      )
+      +
+      # sum of errors
+      sum(rate(http_request_duration_seconds_count{namespace="default",job="fooapp",code=~"5.."}[3d]))
+    )
+    /
+    sum(rate(http_request_duration_seconds_count{namespace="default",job="fooapp"}[3d]))
+  record: http_request_duration_seconds:burnrate3d
+- expr: |
+    (
+      (
+        # sum of too slow requests
+        sum(rate(http_request_duration_seconds_count{namespace="default",job="fooapp",code!~"5.."}[5m]))
+        -
+        sum(rate(http_request_duration_seconds_bucket{namespace="default",job="fooapp",code!~"5..",le="1"}[5m]))
+      )
+      +
+      # sum of errors
+      sum(rate(http_request_duration_seconds_count{namespace="default",job="fooapp",code=~"5.."}[5m]))
+    )
+    /
+    sum(rate(http_request_duration_seconds_count{namespace="default",job="fooapp"}[5m]))
+  record: http_request_duration_seconds:burnrate5m
+- expr: |
+    (
+      (
+        # sum of too slow requests
+        sum(rate(http_request_duration_seconds_count{namespace="default",job="fooapp",code!~"5.."}[6h]))
+        -
+        sum(rate(http_request_duration_seconds_bucket{namespace="default",job="fooapp",code!~"5..",le="1"}[6h]))
+      )
+      +
+      # sum of errors
+      sum(rate(http_request_duration_seconds_count{namespace="default",job="fooapp",code=~"5.."}[6h]))
+    )
+    /
+    sum(rate(http_request_duration_seconds_count{namespace="default",job="fooapp"}[6h]))
+  record: http_request_duration_seconds:burnrate6h

--- a/examples/http-request-errorlatency-burnrate.yaml
+++ b/examples/http-request-errorlatency-burnrate.yaml
@@ -8,6 +8,8 @@ alerts:
     sum(http_request_duration_seconds:burnrate5m) > (14.40 * 0.00100)
   for: 2m
   labels:
+    job: fooapp
+    namespace: default
     severity: critical
 - alert: ErrorBudgetBurn
   annotations:
@@ -18,6 +20,8 @@ alerts:
     sum(http_request_duration_seconds:burnrate30m) > (6.00 * 0.00100)
   for: 15m
   labels:
+    job: fooapp
+    namespace: default
     severity: critical
 - alert: ErrorBudgetBurn
   annotations:
@@ -28,6 +32,8 @@ alerts:
     sum(http_request_duration_seconds:burnrate2h) > (3.00 * 0.00100)
   for: 1h
   labels:
+    job: fooapp
+    namespace: default
     severity: warning
 - alert: ErrorBudgetBurn
   annotations:
@@ -38,6 +44,8 @@ alerts:
     sum(http_request_duration_seconds:burnrate6h) > (1.00 * 0.00100)
   for: 3h
   labels:
+    job: fooapp
+    namespace: default
     severity: warning
 recordingrule:
 - expr: |
@@ -54,6 +62,9 @@ recordingrule:
     )
     /
     sum(rate(http_request_duration_seconds_count{namespace="default",job="fooapp"}[1d]))
+  labels:
+    job: fooapp
+    namespace: default
   record: http_request_duration_seconds:burnrate1d
 - expr: |
     (
@@ -69,6 +80,9 @@ recordingrule:
     )
     /
     sum(rate(http_request_duration_seconds_count{namespace="default",job="fooapp"}[1h]))
+  labels:
+    job: fooapp
+    namespace: default
   record: http_request_duration_seconds:burnrate1h
 - expr: |
     (
@@ -84,6 +98,9 @@ recordingrule:
     )
     /
     sum(rate(http_request_duration_seconds_count{namespace="default",job="fooapp"}[2h]))
+  labels:
+    job: fooapp
+    namespace: default
   record: http_request_duration_seconds:burnrate2h
 - expr: |
     (
@@ -99,6 +116,9 @@ recordingrule:
     )
     /
     sum(rate(http_request_duration_seconds_count{namespace="default",job="fooapp"}[30m]))
+  labels:
+    job: fooapp
+    namespace: default
   record: http_request_duration_seconds:burnrate30m
 - expr: |
     (
@@ -114,6 +134,9 @@ recordingrule:
     )
     /
     sum(rate(http_request_duration_seconds_count{namespace="default",job="fooapp"}[3d]))
+  labels:
+    job: fooapp
+    namespace: default
   record: http_request_duration_seconds:burnrate3d
 - expr: |
     (
@@ -129,6 +152,9 @@ recordingrule:
     )
     /
     sum(rate(http_request_duration_seconds_count{namespace="default",job="fooapp"}[5m]))
+  labels:
+    job: fooapp
+    namespace: default
   record: http_request_duration_seconds:burnrate5m
 - expr: |
     (
@@ -144,4 +170,7 @@ recordingrule:
     )
     /
     sum(rate(http_request_duration_seconds_count{namespace="default",job="fooapp"}[6h]))
+  labels:
+    job: fooapp
+    namespace: default
   record: http_request_duration_seconds:burnrate6h

--- a/slo-libsonnet/errorlatency-burn.libsonnet
+++ b/slo-libsonnet/errorlatency-burn.libsonnet
@@ -1,0 +1,82 @@
+local util = import '_util.libsonnet';
+
+{
+  errorlatencyburn(param):: {
+    local slo = {
+      alertName: 'ErrorBudgetBurn',
+      alertMessage: 'App is burning too much error budget',
+      metric: error 'must set metric for error burn', // This has to be a histogram metric without _bucket or _count
+      recordingrule: '%s:burnrate%%s' % self.metric, // double %% at the end as we template again further on
+      selectors: error 'must set selectors for error burn',
+      target: error 'must set target for error burn',
+      labels: [],
+      codeSelector: 'code',
+      windows: [
+        { severity: 'critical', 'for': '2m', long: '1h', short: '5m', factor: 14.4 },
+        { severity: 'critical', 'for': '15m', long: '6h', short: '30m', factor: 6 },
+        { severity: 'warning', 'for': '1h', long: '1d', short: '2h', factor: 3 },
+        { severity: 'warning', 'for': '3h', long: '3d', short: '6h', factor: 1 },
+      ],
+    } + param,
+
+    local labels =
+      util.selectorsToLabels(slo.selectors) +
+      util.selectorsToLabels(slo.labels),
+
+    recordingrules:
+      [
+        {
+          record: slo.recordingrule % rate,
+          expr: |||
+            (
+              (
+                # sum of too slow requests
+                sum(rate(%(metric)s_count{%(selectors)s,%(codeSelector)s!~"5.."}[%(rate)s]))
+                -
+                sum(rate(%(metric)s_bucket{%(selectors)s,%(codeSelector)s!~"5..",le="1"}[%(rate)s]))
+              )
+              +
+              # sum of errors
+              sum(rate(%(metric)s_count{%(selectors)s,%(codeSelector)s=~"5.."}[%(rate)s]))
+            )
+            /
+            sum(rate(%(metric)s_count{%(selectors)s}[%(rate)s]))
+          ||| % { selectors: std.join(',', slo.selectors), codeSelector: slo.codeSelector, metric: slo.metric, rate: rate },
+        }
+        for rate in std.set([  // Get the unique array of short and long window rates
+          r.short
+          for r in slo.windows
+        ] + [
+          r.long
+          for r in slo.windows
+        ])
+      ],
+
+    alerts:
+      [
+        {
+          alert: slo.alertName,
+          expr: |||
+            sum(%s) > (%.2f * %.5f)
+            and
+            sum(%s) > (%.2f * %.5f)
+          ||| % [
+            slo.recordingrule % w.long,
+            w.factor,
+            (1 - slo.target),
+            slo.recordingrule % w.short,
+            w.factor,
+            (1 - slo.target),
+          ],
+          labels: {
+            severity: w.severity,
+          },
+          annotations: {
+            message: slo.alertMessage,
+          },
+          'for': '%(for)s' % w,
+        }
+        for w in slo.windows
+      ],
+  },
+}

--- a/slo-libsonnet/errorlatency-burn.libsonnet
+++ b/slo-libsonnet/errorlatency-burn.libsonnet
@@ -5,8 +5,8 @@ local util = import '_util.libsonnet';
     local slo = {
       alertName: 'ErrorBudgetBurn',
       alertMessage: 'App is burning too much error budget',
-      metric: error 'must set metric for error burn', // This has to be a histogram metric without _bucket or _count
-      recordingrule: '%s:burnrate%%s' % self.metric, // double %% at the end as we template again further on
+      metric: error 'must set metric for error burn',  // This has to be a histogram metric without _bucket or _count
+      recordingrule: '%s:burnrate%%s' % self.metric,  // double %% at the end as we template again further on
       selectors: error 'must set selectors for error burn',
       target: error 'must set target for error burn',
       labels: [],
@@ -42,6 +42,7 @@ local util = import '_util.libsonnet';
             /
             sum(rate(%(metric)s_count{%(selectors)s}[%(rate)s]))
           ||| % { selectors: std.join(',', slo.selectors), codeSelector: slo.codeSelector, metric: slo.metric, rate: rate },
+          labels: labels,
         }
         for rate in std.set([  // Get the unique array of short and long window rates
           r.short
@@ -68,7 +69,7 @@ local util = import '_util.libsonnet';
             w.factor,
             (1 - slo.target),
           ],
-          labels: {
+          labels: labels {
             severity: w.severity,
           },
           annotations: {

--- a/slo-libsonnet/slo.libsonnet
+++ b/slo-libsonnet/slo.libsonnet
@@ -1,4 +1,5 @@
 (import 'error-burn.libsonnet') +
+(import 'errorlatency-burn.libsonnet') +
 (import 'errors.libsonnet') +
 (import 'latency-burn.libsonnet') +
 (import 'latency.libsonnet')


### PR DESCRIPTION
This only works if a histogram with a status code selector is available, like `code` or `status`.
Otherwise, you should still use `errorburn` or `latencyburn` individually.

I've essentially extracted this from the kubernetes-mixin from the APIServer alerting.

/cc @krasi-georgiev @aditya-konarde @brancz @squat 