### PR TITLE
Improve errors and errorburn closer to errorlatencyburn function

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,9 @@
-all: examples
+all: jsonnetfmt examples
+
+JSONNET_FILES = $(shell find . -type f -not -path './examples/vendor/*' -name '*.libsonnet' -o -name '*.jsonnet')
+
+jsonnetfmt: $(JSONNET_FILES)
+	.bingo/jsonnetfmt -n 2 --max-blank-lines 2 --string-style s --comment-style s -i $(JSONNET_FILES)
 
 examples: examples/vendor examples/http-request-latency-burnrate.yaml examples/http-request-error-burnrate.yaml examples/http-request-errors.yaml examples/http-request-latency.yaml
 
@@ -6,19 +11,15 @@ examples/vendor: examples/jsonnetfile.json examples/jsonnetfile.lock.json .bingo
 	cd examples && ../.bingo/jb install
 
 examples/http-request-error-burnrate.yaml: examples/http-request-error-burnrate.jsonnet .bingo/jsonnetfmt .bingo/jsonnet .bingo/gojsontoyaml
-	.bingo/jsonnetfmt -i examples/http-request-error-burnrate.jsonnet
 	.bingo/jsonnet -J examples/vendor examples/http-request-error-burnrate.jsonnet | .bingo/gojsontoyaml > examples/http-request-error-burnrate.yaml
 
 examples/http-request-errors.yaml: examples/http-request-errors.jsonnet .bingo/jsonnetfmt .bingo/jsonnet .bingo/gojsontoyaml
-	.bingo/jsonnetfmt -i examples/http-request-errors.jsonnet
 	.bingo/jsonnet -J examples/vendor examples/http-request-errors.jsonnet | .bingo/gojsontoyaml > examples/http-request-errors.yaml
 
 examples/http-request-latency-burnrate.yaml: examples/http-request-latency-burnrate.jsonnet .bingo/jsonnetfmt .bingo/jsonnet .bingo/gojsontoyaml
-	.bingo/jsonnetfmt -i examples/http-request-latency-burnrate.jsonnet
 	.bingo/jsonnet -J examples/vendor examples/http-request-latency-burnrate.jsonnet | .bingo/gojsontoyaml > examples/http-request-latency-burnrate.yaml
 
 examples/http-request-latency.yaml: examples/http-request-latency.jsonnet .bingo/jsonnetfmt .bingo/jsonnet .bingo/gojsontoyaml
-	.bingo/jsonnetfmt -i examples/http-request-latency.jsonnet
 	.bingo/jsonnet -J examples/vendor examples/http-request-latency.jsonnet | .bingo/gojsontoyaml > examples/http-request-latency.yaml
 
 .bingo/jb:

--- a/examples/http-request-error-burnrate.jsonnet
+++ b/examples/http-request-error-burnrate.jsonnet
@@ -7,8 +7,7 @@ local slo = import '../slo-libsonnet/slo.libsonnet';
     // However, it is availabe on every Prometheus by default.
     metric: 'promhttp_metric_handler_requests_total',
     selectors: ['namespace="default"', 'job="fooapp"'],
-
-    errorBudget: 1 - 0.999,
+    target: 0.999,  // 99.9%
   }),
 
   // Output these as example

--- a/examples/http-request-error-burnrate.yaml
+++ b/examples/http-request-error-burnrate.yaml
@@ -1,166 +1,106 @@
 alerts:
 - alert: ErrorBudgetBurn
   annotations:
-    message: 'High requests error budget burn for namespace=default,job=fooapp (current value: {{ $value }})'
+    message: 'High error budget burn for namespace=default,job=fooapp (current value: {{ $value }})'
   expr: |
-    (
-      status_class_5xx:promhttp_metric_handler_requests_total:ratio_rate1h{namespace="default",job="fooapp"} > (14.4*0.001000)
-      and
-      status_class_5xx:promhttp_metric_handler_requests_total:ratio_rate5m{namespace="default",job="fooapp"} > (14.4*0.001000)
-    )
-    or
-    (
-      status_class_5xx:promhttp_metric_handler_requests_total:ratio_rate6h{namespace="default",job="fooapp"} > (6*0.001000)
-      and
-      status_class_5xx:promhttp_metric_handler_requests_total:ratio_rate30m{namespace="default",job="fooapp"} > (6*0.001000)
-    )
+    sum(promhttp_metric_handler_requests_total:burnrate5m{namespace="default",job="fooapp"}) > (14.40 * (1-0.99900))
+    and
+    sum(promhttp_metric_handler_requests_total:burnrate1h{namespace="default",job="fooapp"}) > (14.40 * (1-0.99900))
+  for: 2m
   labels:
     job: fooapp
     namespace: default
     severity: critical
 - alert: ErrorBudgetBurn
   annotations:
-    message: 'High requests error budget burn for namespace=default,job=fooapp (current value: {{ $value }})'
+    message: 'High error budget burn for namespace=default,job=fooapp (current value: {{ $value }})'
   expr: |
-    (
-      status_class_5xx:promhttp_metric_handler_requests_total:ratio_rate1d{namespace="default",job="fooapp"} > (3*0.001000)
-      and
-      status_class_5xx:promhttp_metric_handler_requests_total:ratio_rate2h{namespace="default",job="fooapp"} > (3*0.001000)
-    )
-    or
-    (
-      status_class_5xx:promhttp_metric_handler_requests_total:ratio_rate3d{namespace="default",job="fooapp"} > (0.001000)
-      and
-      status_class_5xx:promhttp_metric_handler_requests_total:ratio_rate6h{namespace="default",job="fooapp"} > (0.001000)
-    )
+    sum(promhttp_metric_handler_requests_total:burnrate30m{namespace="default",job="fooapp"}) > (6.00 * (1-0.99900))
+    and
+    sum(promhttp_metric_handler_requests_total:burnrate6h{namespace="default",job="fooapp"}) > (6.00 * (1-0.99900))
+  for: 15m
+  labels:
+    job: fooapp
+    namespace: default
+    severity: critical
+- alert: ErrorBudgetBurn
+  annotations:
+    message: 'High error budget burn for namespace=default,job=fooapp (current value: {{ $value }})'
+  expr: |
+    sum(promhttp_metric_handler_requests_total:burnrate2h{namespace="default",job="fooapp"}) > (3.00 * (1-0.99900))
+    and
+    sum(promhttp_metric_handler_requests_total:burnrate1d{namespace="default",job="fooapp"}) > (3.00 * (1-0.99900))
+  for: 1h
+  labels:
+    job: fooapp
+    namespace: default
+    severity: warning
+- alert: ErrorBudgetBurn
+  annotations:
+    message: 'High error budget burn for namespace=default,job=fooapp (current value: {{ $value }})'
+  expr: |
+    sum(promhttp_metric_handler_requests_total:burnrate6h{namespace="default",job="fooapp"}) > (1.00 * (1-0.99900))
+    and
+    sum(promhttp_metric_handler_requests_total:burnrate3d{namespace="default",job="fooapp"}) > (1.00 * (1-0.99900))
+  for: 3h
   labels:
     job: fooapp
     namespace: default
     severity: warning
 recordingrule:
 - expr: |
-    sum by (status_class) (
-      label_replace(
-        rate(promhttp_metric_handler_requests_total{namespace="default",job="fooapp"}[5m]
-      ), "status_class", "${1}xx", "code", "([0-9])..")
-    )
-  labels:
-    job: fooapp
-    namespace: default
-  record: status_class:promhttp_metric_handler_requests_total:rate5m
-- expr: |
-    sum by (status_class) (
-      label_replace(
-        rate(promhttp_metric_handler_requests_total{namespace="default",job="fooapp"}[30m]
-      ), "status_class", "${1}xx", "code", "([0-9])..")
-    )
-  labels:
-    job: fooapp
-    namespace: default
-  record: status_class:promhttp_metric_handler_requests_total:rate30m
-- expr: |
-    sum by (status_class) (
-      label_replace(
-        rate(promhttp_metric_handler_requests_total{namespace="default",job="fooapp"}[1h]
-      ), "status_class", "${1}xx", "code", "([0-9])..")
-    )
-  labels:
-    job: fooapp
-    namespace: default
-  record: status_class:promhttp_metric_handler_requests_total:rate1h
-- expr: |
-    sum by (status_class) (
-      label_replace(
-        rate(promhttp_metric_handler_requests_total{namespace="default",job="fooapp"}[2h]
-      ), "status_class", "${1}xx", "code", "([0-9])..")
-    )
-  labels:
-    job: fooapp
-    namespace: default
-  record: status_class:promhttp_metric_handler_requests_total:rate2h
-- expr: |
-    sum by (status_class) (
-      label_replace(
-        rate(promhttp_metric_handler_requests_total{namespace="default",job="fooapp"}[6h]
-      ), "status_class", "${1}xx", "code", "([0-9])..")
-    )
-  labels:
-    job: fooapp
-    namespace: default
-  record: status_class:promhttp_metric_handler_requests_total:rate6h
-- expr: |
-    sum by (status_class) (
-      label_replace(
-        rate(promhttp_metric_handler_requests_total{namespace="default",job="fooapp"}[1d]
-      ), "status_class", "${1}xx", "code", "([0-9])..")
-    )
-  labels:
-    job: fooapp
-    namespace: default
-  record: status_class:promhttp_metric_handler_requests_total:rate1d
-- expr: |
-    sum by (status_class) (
-      label_replace(
-        rate(promhttp_metric_handler_requests_total{namespace="default",job="fooapp"}[3d]
-      ), "status_class", "${1}xx", "code", "([0-9])..")
-    )
-  labels:
-    job: fooapp
-    namespace: default
-  record: status_class:promhttp_metric_handler_requests_total:rate3d
-- expr: |
-    sum(status_class:promhttp_metric_handler_requests_total:rate5m{namespace="default",job="fooapp",status_class="5xx"})
+    sum(rate(promhttp_metric_handler_requests_total{namespace="default",job="fooapp",code=~"5.."}[1d]))
     /
-    sum(status_class:promhttp_metric_handler_requests_total:rate5m{namespace="default",job="fooapp"})
+    sum(rate(promhttp_metric_handler_requests_total{namespace="default",job="fooapp"}[1d]))
   labels:
     job: fooapp
     namespace: default
-  record: status_class_5xx:promhttp_metric_handler_requests_total:ratio_rate5m
+  record: promhttp_metric_handler_requests_total:burnrate1d
 - expr: |
-    sum(status_class:promhttp_metric_handler_requests_total:rate30m{namespace="default",job="fooapp",status_class="5xx"})
+    sum(rate(promhttp_metric_handler_requests_total{namespace="default",job="fooapp",code=~"5.."}[1h]))
     /
-    sum(status_class:promhttp_metric_handler_requests_total:rate30m{namespace="default",job="fooapp"})
+    sum(rate(promhttp_metric_handler_requests_total{namespace="default",job="fooapp"}[1h]))
   labels:
     job: fooapp
     namespace: default
-  record: status_class_5xx:promhttp_metric_handler_requests_total:ratio_rate30m
+  record: promhttp_metric_handler_requests_total:burnrate1h
 - expr: |
-    sum(status_class:promhttp_metric_handler_requests_total:rate1h{namespace="default",job="fooapp",status_class="5xx"})
+    sum(rate(promhttp_metric_handler_requests_total{namespace="default",job="fooapp",code=~"5.."}[2h]))
     /
-    sum(status_class:promhttp_metric_handler_requests_total:rate1h{namespace="default",job="fooapp"})
+    sum(rate(promhttp_metric_handler_requests_total{namespace="default",job="fooapp"}[2h]))
   labels:
     job: fooapp
     namespace: default
-  record: status_class_5xx:promhttp_metric_handler_requests_total:ratio_rate1h
+  record: promhttp_metric_handler_requests_total:burnrate2h
 - expr: |
-    sum(status_class:promhttp_metric_handler_requests_total:rate2h{namespace="default",job="fooapp",status_class="5xx"})
+    sum(rate(promhttp_metric_handler_requests_total{namespace="default",job="fooapp",code=~"5.."}[30m]))
     /
-    sum(status_class:promhttp_metric_handler_requests_total:rate2h{namespace="default",job="fooapp"})
+    sum(rate(promhttp_metric_handler_requests_total{namespace="default",job="fooapp"}[30m]))
   labels:
     job: fooapp
     namespace: default
-  record: status_class_5xx:promhttp_metric_handler_requests_total:ratio_rate2h
+  record: promhttp_metric_handler_requests_total:burnrate30m
 - expr: |
-    sum(status_class:promhttp_metric_handler_requests_total:rate6h{namespace="default",job="fooapp",status_class="5xx"})
+    sum(rate(promhttp_metric_handler_requests_total{namespace="default",job="fooapp",code=~"5.."}[3d]))
     /
-    sum(status_class:promhttp_metric_handler_requests_total:rate6h{namespace="default",job="fooapp"})
+    sum(rate(promhttp_metric_handler_requests_total{namespace="default",job="fooapp"}[3d]))
   labels:
     job: fooapp
     namespace: default
-  record: status_class_5xx:promhttp_metric_handler_requests_total:ratio_rate6h
+  record: promhttp_metric_handler_requests_total:burnrate3d
 - expr: |
-    sum(status_class:promhttp_metric_handler_requests_total:rate1d{namespace="default",job="fooapp",status_class="5xx"})
+    sum(rate(promhttp_metric_handler_requests_total{namespace="default",job="fooapp",code=~"5.."}[5m]))
     /
-    sum(status_class:promhttp_metric_handler_requests_total:rate1d{namespace="default",job="fooapp"})
+    sum(rate(promhttp_metric_handler_requests_total{namespace="default",job="fooapp"}[5m]))
   labels:
     job: fooapp
     namespace: default
-  record: status_class_5xx:promhttp_metric_handler_requests_total:ratio_rate1d
+  record: promhttp_metric_handler_requests_total:burnrate5m
 - expr: |
-    sum(status_class:promhttp_metric_handler_requests_total:rate3d{namespace="default",job="fooapp",status_class="5xx"})
+    sum(rate(promhttp_metric_handler_requests_total{namespace="default",job="fooapp",code=~"5.."}[6h]))
     /
-    sum(status_class:promhttp_metric_handler_requests_total:rate3d{namespace="default",job="fooapp"})
+    sum(rate(promhttp_metric_handler_requests_total{namespace="default",job="fooapp"}[6h]))
   labels:
     job: fooapp
     namespace: default
-  record: status_class_5xx:promhttp_metric_handler_requests_total:ratio_rate3d
+  record: promhttp_metric_handler_requests_total:burnrate6h

--- a/examples/http-request-errors.jsonnet
+++ b/examples/http-request-errors.jsonnet
@@ -4,17 +4,14 @@ local slo = import '../slo-libsonnet/slo.libsonnet';
   local errors = slo.errors({
     metric: 'promhttp_metric_handler_requests_total',
     selectors: ['namespace="default"', 'job="fooapp"'],
+    errorSelector: ['code=~"5.."'],
 
     warning: 0.05,  // 5% of total requests
     critical: 0.1,  // 10% of total requests
   }),
 
   // Output these as example
-  recordingrule: errors.recordingrule,
-  alerts: [
-    errors.alertWarning,
-    errors.alertCritical,
-  ],
+  alerts: errors.alerts,
   grafana: {
     graph: std.toString(errors.grafana.graph),
   },

--- a/examples/http-request-errors.yaml
+++ b/examples/http-request-errors.yaml
@@ -1,10 +1,11 @@
 alerts:
 - expr: |
     (
-      sum(status_class:promhttp_metric_handler_requests_total:rate5m{status_class="5xx"})
-    /
-      sum(status_class:promhttp_metric_handler_requests_total:rate5m)
-    ) > 0.050000000000000003
+      sum(rate(promhttp_metric_handler_requests_total{namespace="default",job="fooapp",code=~"5.."}[5m]))
+      /
+      sum(rate(promhttp_metric_handler_requests_total{namespace="default",job="fooapp"}[5m]))
+    )
+    > 0.050000
   for: 5m
   labels:
     job: fooapp
@@ -12,25 +13,15 @@ alerts:
     severity: warning
 - expr: |
     (
-      sum(status_class:promhttp_metric_handler_requests_total:rate5m{status_class="5xx"})
-    /
-      sum(status_class:promhttp_metric_handler_requests_total:rate5m)
-    ) > 0.10000000000000001
+      sum(rate(promhttp_metric_handler_requests_total{namespace="default",job="fooapp",code=~"5.."}[5m]))
+      /
+      sum(rate(promhttp_metric_handler_requests_total{namespace="default",job="fooapp"}[5m]))
+    )
+    > 0.100000
   for: 5m
   labels:
     job: fooapp
     namespace: default
     severity: critical
 grafana:
-  graph: '{"aliasColors": {"1xx": "#EAB839", "2xx": "#7EB26D", "3xx": "#6ED0E0", "4xx": "#EF843C", "5xx": "#E24D42", "error": "#E24D42", "success": "#7EB26D"}, "datasource": "$datasource", "legend": {"avg": false, "current": false, "max": false, "min": false, "show": true, "total": false, "values": false}, "span": 12, "targets": [{"expr": "status_class:promhttp_metric_handler_requests_total:rate5m", "format": "time_series", "intervalFactor": 2, "legendFormat": "{{status_class}}", "refId": "A", "step": 10}], "title": "HTTP Response Codes", "tooltip": {"shared": true, "sort": 0, "value_type": "individual"}, "type": "graph"}'
-recordingrule:
-  expr: |
-    sum by (status_class) (
-      label_replace(
-        rate(promhttp_metric_handler_requests_total{namespace="default",job="fooapp"}[5m]
-      ), "status_class", "${1}xx", "code", "([0-9])..")
-    )
-  labels:
-    job: fooapp
-    namespace: default
-  record: status_class:promhttp_metric_handler_requests_total:rate5m
+  graph: '{"datasource": "$datasource", "legend": {"avg": false, "current": false, "max": false, "min": false, "show": true, "total": false, "values": false}, "seriesOverrides": [{"alias": "/2../", "color": "#56A64B"}, {"alias": "/3../", "color": "#F2CC0C"}, {"alias": "/4../", "color": "#3274D9"}, {"alias": "/5../", "color": "#E02F44"}], "targets": [{"expr": "promhttp_metric_handler_requests_total{{\"job\": \"fooapp\", \"namespace\": \"default\"}}", "format": "time_series", "intervalFactor": 2, "legendFormat": "{{code}}", "refId": "A", "step": 10}], "title": "HTTP Response Codes", "tooltip": {"shared": true, "sort": 0, "value_type": "individual"}, "type": "graph"}'

--- a/slo-libsonnet/error-burn.libsonnet
+++ b/slo-libsonnet/error-burn.libsonnet
@@ -4,139 +4,74 @@ local errors = import 'errors.libsonnet';
   errorburn(param):: {
     local slo = {
       alertName: 'ErrorBudgetBurn',
+      alertMessage: 'High error budget burn for %s (current value: {{ $value }})' % [std.strReplace(std.join(',', self.selectors), '"', '')],
       metric: error 'must set metric for error burn',
-      selectors: error 'must set selectors for error burn',
-      errorBudget: error 'must set errorBudget for error burn',
-      labels: [],
-      codeSelector: 'code',
+      recordingrule: '%s:burnrate%%s' % self.metric,  // double %% at the end as we template again further on
+      selectors: [],
+      errorSelectors: ['code=~"5.."'],
+      target:
+        if std.objectHas(param, 'errorBudget') then  // compatibility for a couple of months
+          1 - param.errorBudget
+        else
+          error 'must set target for error burn',
+      windows: [
+        { severity: 'critical', 'for': '2m', long: '1h', short: '5m', factor: 14.4 },
+        { severity: 'critical', 'for': '15m', long: '6h', short: '30m', factor: 6 },
+        { severity: 'warning', 'for': '1h', long: '1d', short: '2h', factor: 3 },
+        { severity: 'warning', 'for': '3h', long: '3d', short: '6h', factor: 1 },
+      ],
     } + param,
 
-    local rates = ['5m', '30m', '1h', '2h', '6h', '1d', '3d'],
+    local labels = util.selectorsToLabels(slo.selectors),
 
-    local labels =
-      util.selectorsToLabels(slo.selectors) +
-      util.selectorsToLabels(slo.labels),
-
-    local errorRatesWithRate = [
-      errors.errors({
-        metric: slo.metric,
-        selectors: slo.selectors,
-        rate: rate,
-        codeSelector: slo.codeSelector,
-      }).recordingrule {
-        // We need to communicate the rate to the errorPercentage step
-        // They will be remove after that again
-        labels+: { __tmpRate__: rate },
-      }
-      for rate in rates
-    ],
-
-    local errorPercentages = [
+    recordingrules: [
       {
         expr: |||
-          sum(%s{%s})
+          sum(rate(%(metric)s{%(errorSelectors)s}[%(rate)s]))
           /
-          sum(%s{%s})
-        ||| % [
-          err.record,
-          std.join(',', slo.selectors + ['status_class="5xx"']),
-          err.record,
-          std.join(',', slo.selectors),
-        ],
-        record: 'status_class_5xx:%s:ratio_rate%s' % [slo.metric, err.labels.__tmpRate__],
+          sum(rate(%(metric)s{%(selectors)s}[%(rate)s]))
+        ||| % {
+          metric: slo.metric,
+          selectors: std.join(',', slo.selectors),
+          errorSelectors: std.join(',', slo.selectors + slo.errorSelectors),
+          rate: rate,
+        },
+        record: slo.recordingrule % rate,
         labels: labels,
       }
-      for err in errorRatesWithRate
+      for rate in std.set([  // Get the unique array of short and long window rates
+        r.short
+        for r in slo.windows
+      ] + [
+        r.long
+        for r in slo.windows
+      ])
     ],
 
-    // Remove __tmpRate__ label from errorRates rules again
-    local errorRates = std.map(
-      function(rule) rule {
-        local ls = super.labels,
-        labels: {
-          [k]: ls[k]
-          for k in std.objectFields(ls)
-          if !std.setMember(k, ['__tmpRate__'])
-        },
-      },
-      errorRatesWithRate,
-    ),
-
-    recordingrules: errorRates + errorPercentages,
-
-    local multiBurnRate30d = [
-      {
-        alert: slo.alertName,
-        expr: |||
-          (
-            %s{%s} > (14.4*%f)
+    alerts:
+      [
+        {
+          alert: slo.alertName,
+          expr: |||
+            sum(%(recordingruleShort)s{%(selectors)s}) > (%(factor).2f * (1-%(target).5f))
             and
-            %s{%s} > (14.4*%f)
-          )
-          or
-          (
-            %s{%s} > (6*%f)
-            and
-            %s{%s} > (6*%f)
-          )
-        ||| % [
-          errorPercentages[2].record,
-          std.join(',', slo.selectors),
-          slo.errorBudget,
-          errorPercentages[0].record,
-          std.join(',', slo.selectors),
-          slo.errorBudget,
-          errorPercentages[4].record,
-          std.join(',', slo.selectors),
-          slo.errorBudget,
-          errorPercentages[1].record,
-          std.join(',', slo.selectors),
-          slo.errorBudget,
-        ],
-        labels: labels {
-          severity: 'critical',
-        },
-        annotations: {
-          message: 'High requests error budget burn for %s (current value: {{ $value }})' % [std.strReplace(std.join(',', slo.selectors), '"', '')],
-        },
-      },
-      {
-        alert: slo.alertName,
-        expr: |||
-          (
-            %s{%s} > (3*%f)
-            and
-            %s{%s} > (3*%f)
-          )
-          or
-          (
-            %s{%s} > (%f)
-            and
-            %s{%s} > (%f)
-          )
-        ||| % [
-          errorPercentages[5].record,
-          std.join(',', slo.selectors),
-          slo.errorBudget,
-          errorPercentages[3].record,
-          std.join(',', slo.selectors),
-          slo.errorBudget,
-          errorPercentages[6].record,
-          std.join(',', slo.selectors),
-          slo.errorBudget,
-          errorPercentages[4].record,
-          std.join(',', slo.selectors),
-          slo.errorBudget,
-        ],
-        labels: labels {
-          severity: 'warning',
-        },
-        annotations: {
-          message: 'High requests error budget burn for %s (current value: {{ $value }})' % [std.strReplace(std.join(',', slo.selectors), '"', '')],
-        },
-      },
-    ],
-
-    alerts: multiBurnRate30d,
+            sum(%(recordingruleLong)s{%(selectors)s}) > (%(factor).2f * (1-%(target).5f))
+          ||| % {
+            recordingruleShort: slo.recordingrule % w.short,
+            recordingruleLong: slo.recordingrule % w.long,
+            selectors: std.join(',', slo.selectors),
+            target: slo.target,
+            factor: w.factor,
+          },
+          labels: labels {
+            severity: w.severity,
+          },
+          annotations: {
+            message: slo.alertMessage,
+          },
+          'for': '%(for)s' % w,
+        }
+        for w in slo.windows
+      ],
   },
 }


### PR DESCRIPTION
In another PR I propose the merge the errorlatencyburn function which is basically extracted from the learnings I had during creating multi error burn rate alerts for the APIServer.

Taking these improvements back to errors and errorburn is a logical next step. Once we discussed these here, we can also improve latencyburn.

I think this makes a couple of things a lot easier. :)

/cc @krasi-georgiev @brancz @aditya-konarde @kakkoyun @squat