### PR TITLE
Generic latency slo

### DIFF
--- a/slo-libsonnet/latency-burn.libsonnet
+++ b/slo-libsonnet/latency-burn.libsonnet
@@ -9,6 +9,7 @@ local util = import '_util.libsonnet';
       latencyBudget: error 'must set latencyBudget latency burn',
       labels: [],
       codeSelector: 'code',
+      notErrorSelector: '%s!~"5.."' % slo.codeSelector,
     } + param,
 
     local rates = ['5m', '30m', '1h', '2h', '6h', '1d', '3d'],
@@ -23,7 +24,7 @@ local util = import '_util.libsonnet';
         // This gives the total requests that fail the SLO
         expr: |||
           1 - (
-            sum(rate(%s{%s,le="%s",%s!~"5.."}[%s]))
+            sum(rate(%s{%s,le="%s",%s}[%s]))
             /
             sum(rate(%s{%s}[%s]))
           )
@@ -31,7 +32,7 @@ local util = import '_util.libsonnet';
           slo.metric + '_bucket',
           std.join(',', slo.selectors),
           slo.latencyTarget,
-          slo.codeSelector,
+          slo.notErrorSelector,
           rate,
           slo.metric + '_count',
           std.join(',', slo.selectors),

--- a/slo-libsonnet/latency-burn.libsonnet
+++ b/slo-libsonnet/latency-burn.libsonnet
@@ -24,20 +24,18 @@ local util = import '_util.libsonnet';
         // This gives the total requests that fail the SLO
         expr: |||
           1 - (
-            sum(rate(%s{%s,le="%s",%s}[%s]))
+            sum(rate(%(bucketMetric)s{%(selectors)s,le="%(latencyTarget)s",%(notErrorSelector)s}[%(rate)s]))
             /
-            sum(rate(%s{%s}[%s]))
+            sum(rate(%(countMetric)s{%(selectors)s}[%(rate)s]))
           )
-        ||| % [
-          slo.metric + '_bucket',
-          std.join(',', slo.selectors),
-          slo.latencyTarget,
-          slo.notErrorSelector,
-          rate,
-          slo.metric + '_count',
-          std.join(',', slo.selectors),
-          rate,
-        ],
+        ||| % {
+          bucketMetric: slo.metric + '_bucket',
+          selectors: std.join(',', slo.selectors),
+          latencyTarget: slo.latencyTarget,
+          notErrorSelector: slo.notErrorSelector,
+          rate: rate,
+          countMetric: slo.metric + '_count',
+        },
         record: 'latencytarget:%s:rate%s' % [slo.metric, rate],
         labels: util.selectorsToLabels(rulesSelectors),
       }

--- a/slo-libsonnet/latency-burn.libsonnet
+++ b/slo-libsonnet/latency-burn.libsonnet
@@ -5,6 +5,9 @@ local util = import '_util.libsonnet';
       alertName: 'LatencyBudgetBurn',
       metric: error 'must set metric for latency burn',
       selectors: error 'must set selectors for latency burn',
+
+      // Note, the latency target must be available as an exact histogram
+      // bucket. As recording rules rely on it.
       latencyTarget: error 'must set latencyTarget latency burn',
       latencyBudget: error 'must set latencyBudget latency burn',
       labels: [],


### PR DESCRIPTION
This PR has 3 changes:

* Introduce notErrorSelector

The notErrorSelector allows using the latency burn function for metrics
other than those that have errors defined as not 5xx.

* Template latency rules with named fields …

Reading and understanding the code was very difficult as the parameters
had to be counted, now it's much easier to reason about.

* Add note about requirement of histogram bucket

@metalmatze 

If I'm not mistaken then this should largely solve https://github.com/metalmatze/slo-libsonnet/issues/15