### PR TITLE
Support regex selectors for latencyburn SLO

### DIFF
--- a/slo-libsonnet/latency-burn.libsonnet
+++ b/slo-libsonnet/latency-burn.libsonnet
@@ -18,6 +18,7 @@ local util = import '_util.libsonnet';
     local rates = ['5m', '30m', '1h', '2h', '6h', '1d', '3d'],
 
     local rulesSelectors = slo.selectors + ['latency="' + slo.latencyTarget + '"'],
+    local alertSelectors = std.strReplace(std.join(',', rulesSelectors), '=~', '='),
 
     local latencyRules = [
       {
@@ -66,16 +67,16 @@ local util = import '_util.libsonnet';
           )
         ||| % [
           latencyRules[2].record,
-          std.join(',', rulesSelectors),
+          alertSelectors,
           slo.latencyBudget,
           latencyRules[0].record,
-          std.join(',', rulesSelectors),
+          alertSelectors,
           slo.latencyBudget,
           latencyRules[4].record,
-          std.join(',', rulesSelectors),
+          alertSelectors,
           slo.latencyBudget,
           latencyRules[1].record,
-          std.join(',', rulesSelectors),
+          alertSelectors,
           slo.latencyBudget,
         ],
         labels: util.selectorsToLabels(rulesSelectors) {
@@ -101,16 +102,16 @@ local util = import '_util.libsonnet';
           )
         ||| % [
           latencyRules[5].record,
-          std.join(',', rulesSelectors),
+          alertSelectors,
           slo.latencyBudget,
           latencyRules[3].record,
-          std.join(',', rulesSelectors),
+          alertSelectors,
           slo.latencyBudget,
           latencyRules[6].record,
-          std.join(',', rulesSelectors),
+          alertSelectors,
           slo.latencyBudget,
           latencyRules[4].record,
-          std.join(',', rulesSelectors),
+          alertSelectors,
           slo.latencyBudget,
         ],
         labels: util.selectorsToLabels(rulesSelectors) {


### PR DESCRIPTION
Have noticed that providing any regex selectors to the latencyburn SLO causes the generated alert to not correctly select the recorded metric.

For example passing `selectors: ['ingress=~"foo|bar"']` will create a recording rule with the label `ingress="foo|bar"`. When the alert rule is later generated, currently we're still using the regex selector in the alert rules, which will cause the `foo|bar` in this example to not match. 

This PR should fix this, by not using the regex selector when the alert rule queries recorded rules. 

I'm not sure if it's intended to support regex selectors with slo-libsonnet or not? Looking at some of the other SLOs, might be a similar issue with those too? Happy to add the fix for those as well. However if it's not intended, perhaps we could add a warning or validate no regex selectors are passed instead? I really only caught this when an SLO alert I _knew_ should have been firing, wasn't. Pre-existing issue though so no harm done :slightly_smiling_face:.