### PR TITLE
Don't add negative label selectors to rules/alerts

### DIFF
--- a/slo-libsonnet/_util.libsonnet
+++ b/slo-libsonnet/_util.libsonnet
@@ -5,5 +5,6 @@
       std.split(s, '=')
       for s in labelset
     ]
+    if s[0] == std.strReplace(s[0], '!', '')
   },
 }


### PR DESCRIPTION
This filters out any negative label selectors from the function used to prepare labels to be added to recording rules and alerts.

Currently if a negative selector is used, such as `ingress!="internal-admin"`, invalid label names are generated that makes promtool linting unhappy.

```
./manifests/prometheus_alerts.yaml: group "Foo", rule 1, "latencytarget:nginx_ingress_controller_request_duration_seconds:rate5m": invalid label name: ingress!
```
This change simply drops the negative label selectors from being returned by this function. Negative selectors are still used on the alerts querying recording rules. This should be fine as there's no label to match on, but some could consider it messy? For cosmetic reasons could perhaps also filter negative selectors out of the alert rules, what do you think?